### PR TITLE
feat: add electron base

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,62 @@
+import { app, BrowserWindow, Menu } from 'electron';
+import path from 'node:path';
+import { autoUpdater } from 'electron-updater';
+
+let mainWindow: BrowserWindow | null = null;
+const isDev = !app.isPackaged;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  const template = [
+    {
+      label: 'File',
+      submenu: [{ role: 'quit' }],
+    },
+  ];
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+
+  mainWindow.on('resize', () => {
+    const bounds = mainWindow?.getBounds();
+    if (bounds) mainWindow?.webContents.send('window-resize', bounds);
+  });
+
+  if (isDev) {
+    mainWindow.loadURL('http://localhost:5173');
+    mainWindow.webContents.openDevTools();
+  } else {
+    const indexHtml = path.join(__dirname, '../dist/index.html');
+    mainWindow.loadFile(indexHtml);
+    autoUpdater.checkForUpdatesAndNotify();
+  }
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+autoUpdater.setFeedURL({ url: 'https://example.com/updates' });
+autoUpdater.on('update-downloaded', () => {
+  autoUpdater.quitAndInstall();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,7 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  onWindowResize: (callback: (event: Electron.IpcRendererEvent, bounds: Electron.Rectangle) => void) =>
+    ipcRenderer.on('window-resize', callback),
+  versions: process.versions,
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start-electron": "npm run build-electron && electron .",
+    "build-electron": "tsc electron/main.ts electron/preload.ts --outDir dist-electron",
+    "dev:desktop": "concurrently \"npm run dev\" \"npm run start-electron\"",
+    "build:desktop": "npm run build && electron-builder --mac"
   },
   "dependencies": {
     "@base44/sdk": "^0.1.2",
@@ -75,6 +79,19 @@
     "globals": "^15.14.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "vite": "^6.1.0"
+    "vite": "^6.1.0",
+    "electron": "*",
+    "electron-builder": "*",
+    "electron-updater": "*",
+    "concurrently": "*",
+    "typescript": "*"
+  },
+  "main": "dist-electron/main.js",
+  "build": {
+    "appId": "com.focana.app",
+    "mac": {
+      "target": "dmg",
+      "identity": null
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add basic Electron main and preload scripts
- wire up autoUpdater and window resize events
- configure package for desktop builds with electron-builder

## Testing
- `npm run dev:desktop` *(fails: concurrently: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e14b724c832c8c793deeeec4c44e