### PR TITLE
fix: resolve electron build errors

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow, Menu } from 'electron';
-import path from 'node:path';
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from 'electron';
+import * as path from 'node:path';
 import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
@@ -14,10 +14,10 @@ function createWindow() {
     },
   });
 
-  const template = [
+  const template: MenuItemConstructorOptions[] = [
     {
       label: 'File',
-      submenu: [{ role: 'quit' }],
+      submenu: [{ role: 'quit' as const }],
     },
   ];
   const menu = Menu.buildFromTemplate(template);
@@ -50,7 +50,7 @@ app.whenReady().then(() => {
   });
 });
 
-autoUpdater.setFeedURL({ url: 'https://example.com/updates' });
+autoUpdater.setFeedURL({ provider: 'generic', url: 'https://example.com/updates' });
 autoUpdater.on('update-downloaded', () => {
   autoUpdater.quitAndInstall();
 });


### PR DESCRIPTION
## Summary
- fix electron path import and menu typings
- add provider to autoUpdater feed URL

## Testing
- `npm run lint` *(fails: numerous eslint errors in existing code)*
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68b9bbfe4804832c8e61a3686a2b88e5