### PR TITLE
fix: resolve electron runtime module error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+dist-electron
 *.local
 
 # Editor directories and files

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow, Menu } from 'electron';
-import path from 'node:path';
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from 'electron';
+import * as path from 'node:path';
 import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
@@ -10,14 +10,14 @@ function createWindow() {
     width: 1200,
     height: 800,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, 'preload.cjs'),
     },
   });
 
-  const template = [
+  const template: MenuItemConstructorOptions[] = [
     {
       label: 'File',
-      submenu: [{ role: 'quit' }],
+      submenu: [{ role: 'quit' as const }],
     },
   ];
   const menu = Menu.buildFromTemplate(template);
@@ -50,7 +50,7 @@ app.whenReady().then(() => {
   });
 });
 
-autoUpdater.setFeedURL({ url: 'https://example.com/updates' });
+autoUpdater.setFeedURL({ provider: 'generic', url: 'https://example.com/updates' });
 autoUpdater.on('update-downloaded', () => {
   autoUpdater.quitAndInstall();
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start-electron": "npm run build-electron && electron .",
+    "start-electron": "npm run build-electron && electron dist-electron/main.cjs",
     "build-electron": "tsc electron/main.ts electron/preload.ts --outDir dist-electron && mv dist-electron/main.js dist-electron/main.cjs && mv dist-electron/preload.js dist-electron/preload.cjs",
     "dev:desktop": "concurrently \"npm run dev\" \"npm run start-electron\"",
     "build:desktop": "npm run build && electron-builder --mac"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "start-electron": "npm run build-electron && electron .",
-    "build-electron": "tsc electron/main.ts electron/preload.ts --outDir dist-electron",
+    "build-electron": "tsc electron/main.ts electron/preload.ts --outDir dist-electron && mv dist-electron/main.js dist-electron/main.cjs && mv dist-electron/preload.js dist-electron/preload.cjs",
     "dev:desktop": "concurrently \"npm run dev\" \"npm run start-electron\"",
     "build:desktop": "npm run build && electron-builder --mac"
   },
@@ -86,7 +86,7 @@
     "vite": "^6.1.0",
     "wait-on": "^8.0.4"
   },
-  "main": "dist-electron/main.js",
+  "main": "dist-electron/main.cjs",
   "build": {
     "appId": "com.focana.app",
     "mac": {


### PR DESCRIPTION
## Summary
- build electron entry points as CommonJS and update preload path
- adjust package.json scripts and main entry for .cjs output
- ignore dist-electron build artifacts

## Testing
- `npm run lint` *(fails: 412 errors, 6 warnings)*
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68b9bbfe4804832c8e61a3686a2b88e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-update configuration to enhance reliability across environments.

* **Chores**
  * Standardized Electron build to CommonJS outputs for more predictable startup.
  * Adjusted application preload resolution to match new build output.
  * Updated start scripts to align with the new entry point.
  * Added additional build artifacts to the ignore list to keep repositories clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->