### PR TITLE
Set application title to Focana

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
+    title: 'Focana',
     webPreferences: {
       preload: path.join(__dirname, 'preload.cjs'),
     },

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Base44 APP</title>
+    <title>Focana</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- replace HTML page title with "Focana"
- configure Electron BrowserWindow to use "Focana" title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 418 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1a94bd4832c98ffd1622ab2adbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated the application window title to “Focana” for consistent branding across the desktop app.
  * Updated the HTML page title to “Focana,” ensuring the browser/tab title matches the app name.
  * Replaces the previous title text (“Base44 APP”) for clearer identification in task switchers, window lists, and tab bars.
  * No functional changes; this is a visual branding update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->