### PR TITLE
Align Electron window with card dimensions

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,14 +1,22 @@
-import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electron';
 import * as path from 'node:path';
 import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
 const isDev = !app.isPackaged;
 
+ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
+  if (mainWindow) {
+    const current = mainWindow.getBounds();
+    mainWindow.setBounds({ ...current, ...bounds });
+  }
+});
+
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    width: 384,
+    height: 336,
+    resizable: false,
     title: 'Focana',
     webPreferences: {
       preload: path.join(__dirname, 'preload.cjs'),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,5 +3,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('electronAPI', {
   onWindowResize: (callback: (event: Electron.IpcRendererEvent, bounds: Electron.Rectangle) => void) =>
     ipcRenderer.on('window-resize', callback),
+  setCardBounds: (bounds: Electron.Rectangle) => ipcRenderer.send('card-bounds', bounds),
   versions: process.versions,
 });

--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -75,6 +75,31 @@ export default function AnchorApp() {
     }
   }, []);
 
+  // Keep Electron window in sync with card size
+  useEffect(() => {
+    if (!window.electronAPI?.setCardBounds || !dragRef.current) return;
+
+    const sendBounds = (width, height) => {
+      window.electronAPI.setCardBounds({
+        width: Math.round(width),
+        height: Math.round(height),
+      });
+    };
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        sendBounds(width, height);
+      }
+    });
+
+    observer.observe(dragRef.current);
+    const rect = dragRef.current.getBoundingClientRect();
+    sendBounds(rect.width, rect.height);
+
+    return () => observer.disconnect();
+  }, []);
+
   // Handle dragging logic
   useEffect(() => {
     const onMouseDown = (e) => {


### PR DESCRIPTION
## Summary
- set BrowserWindow to card dimensions and disable manual resizing
- sync card size to main process via IPC to resize window dynamically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68c0a2d27140832ca9004ec7137e30d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The window now automatically adjusts its size to match the Anchor card.
  * Introduced a compact default window size for a cleaner, focused experience.
  * The window is now fixed-size (non-resizable) to maintain consistent layout and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->