### PR TITLE
Conditionally open DevTools in Electron main process

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,7 +39,9 @@ function createWindow() {
 
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173');
-    mainWindow.webContents.openDevTools();
+    if (process.env.OPEN_DEVTOOLS === 'true') {
+      mainWindow.webContents.openDevTools();
+    }
   } else {
     const indexHtml = path.join(__dirname, '../dist/index.html');
     mainWindow.loadFile(indexHtml);


### PR DESCRIPTION
## Summary
- Only open Electron DevTools when `OPEN_DEVTOOLS` environment variable is set

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 418 lint errors)*
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68c0aa6da720832c9847f1eaf027a661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development builds no longer open DevTools automatically; they will only open when the OPEN_DEVTOOLS environment variable is set to "true".
  * Default behavior in development is unchanged aside from DevTools not auto-opening, offering an opt-in experience for debugging.
  * No impact on production builds: application startup, window loading, and update behavior remain the same, with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->