### PR TITLE
guard card bounds update

### DIFF
--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -80,10 +80,12 @@ export default function AnchorApp() {
     if (!window.electronAPI?.setCardBounds || !dragRef.current) return;
 
     const sendBounds = (width, height) => {
-      window.electronAPI.setCardBounds({
-        width: Math.round(width),
-        height: Math.round(height),
-      });
+      if (width > 0 && height > 0) {
+        window.electronAPI.setCardBounds({
+          width: Math.round(width),
+          height: Math.round(height),
+        });
+      }
     };
 
     const observer = new ResizeObserver((entries) => {
@@ -94,8 +96,10 @@ export default function AnchorApp() {
     });
 
     observer.observe(dragRef.current);
-    const rect = dragRef.current.getBoundingClientRect();
-    sendBounds(rect.width, rect.height);
+    requestAnimationFrame(() => {
+      const rect = dragRef.current.getBoundingClientRect();
+      sendBounds(rect.width, rect.height);
+    });
 
     return () => observer.disconnect();
   }, []);


### PR DESCRIPTION
## Summary
- avoid sending zero-sized bounds to electron
- defer initial bounds measurement until after layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 412 errors, 6 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c0ab68ef98832c8a18306a40438a87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents sending invalid (zero/negative) window bounds, reducing incorrect positioning and layout glitches.
  * Defers initial bounds measurement to the next animation frame for accurate sizing after layout.
  * Rounds measured bounds before applying, improving consistency.

* **Performance**
  * Smoother initialization of draggable elements, reducing flicker or jitter during app startup and initial render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->