### PR TITLE
Align Electron window with card dimensions

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,8 +7,13 @@ const isDev = !app.isPackaged;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    width: 384,
+    height: 336,
+    minWidth: 384,
+    minHeight: 336,
+    maxWidth: 384,
+    maxHeight: 336,
+    resizable: false,
     title: 'Focana',
     webPreferences: {
       preload: path.join(__dirname, 'preload.cjs'),
@@ -24,14 +29,8 @@ function createWindow() {
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 
-  mainWindow.on('resize', () => {
-    const bounds = mainWindow?.getBounds();
-    if (bounds) mainWindow?.webContents.send('window-resize', bounds);
-  });
-
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173');
-    mainWindow.webContents.openDevTools();
   } else {
     const indexHtml = path.join(__dirname, '../dist/index.html');
     mainWindow.loadFile(indexHtml);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,7 +1,5 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  onWindowResize: (callback: (event: Electron.IpcRendererEvent, bounds: Electron.Rectangle) => void) =>
-    ipcRenderer.on('window-resize', callback),
   versions: process.versions,
 });


### PR DESCRIPTION
## Summary
- enforce fixed 384×336 bounds with matching min/max limits in BrowserWindow
- drop window-resize IPC channel from main and preload scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 412 errors, 6 warnings)*
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68c0a2d27140832ca9004ec7137e30d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Main application window is now fixed-size at 1200×800 and cannot be resized.
  - Window resize events/handling have been removed (app no longer propagates resize changes).
- Chores
  - Preload/bridge surface remains unchanged for end-users (exposed APIs and versions unaffected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->