### PR TITLE
Fix missing ipcRenderer import in preload

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   onWindowResize: (callback: (event: Electron.IpcRendererEvent, bounds: Electron.Rectangle) => void) =>


### PR DESCRIPTION
## Summary
- import `ipcRenderer` in the electron preload script to resolve TypeScript compile error

## Testing
- `npm run build-electron`
- `npm run lint` *(fails: 'no-unused-vars', missing prop types, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c1e699f5e0832c88cda53dcf3b95d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved stability of window resize behavior in the desktop app, reducing missed updates during rapid resizing.
  * Made card positioning updates more reliable, minimizing occasional glitches when adjusting layouts.

* Chores
  * Updated internal communication between the app and system layer with no changes to the public interface or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->