### PR TITLE
Gate card mode resizing and ignore tiny window state

### DIFF
--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { FocusSession } from "@/api/entities";
 
+const isCardMode = import.meta.env.VITE_CARD_MODE === 'true';
+
 import DistractionJar from "../components/DistractionJar";
 import StatusBar from "../components/StatusBar";
 import SessionNotesModal from "../components/SessionNotesModal";
@@ -77,7 +79,7 @@ export default function AnchorApp() {
 
   // Keep Electron window in sync with card size
   useEffect(() => {
-    if (!window.electronAPI?.setCardBounds || !dragRef.current) return;
+    if (!isCardMode || !window.electronAPI?.setCardBounds || !dragRef.current) return;
 
     const sendBounds = (width, height) => {
       if (width > 0 && height > 0) {


### PR DESCRIPTION
## Summary
- Only adjust Electron window bounds in card mode
- Avoid resizing desktop window from Anchor page unless in card mode
- Ignore persisted window size if below a minimum threshold

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars, missing prop-types, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c36f177460832c90c443ac5ebf89c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforces a minimum app window size (400×300) for better usability.
  - Card Mode: window size/position syncing now applies only in Card Mode, avoiding unintended resizing in standard mode.

- Bug Fixes
  - Invalid saved window state with too-small dimensions is now discarded and regenerated, preventing launch into unusable sizes.
  - Window bounds are applied only when the main window is available and Card Mode is active, reducing startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->