### PR TITLE
Match Electron window to Anchor card

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,7 +5,8 @@ import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
 const isDev = !app.isPackaged;
-const isCardMode = process.env.CARD_MODE === 'true';
+// Default to card mode unless explicitly disabled
+const isCardMode = process.env.CARD_MODE !== 'false';
 
 ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
   if (mainWindow && isCardMode) {
@@ -19,27 +20,34 @@ function createWindow() {
   const MIN_WIDTH = 400;
   const MIN_HEIGHT = 300;
   let state: Partial<Electron.Rectangle> = {};
-  try {
-    state = JSON.parse(fs.readFileSync(stateStoreFile, 'utf8'));
-    if (
-      typeof state.width === 'number' &&
-      typeof state.height === 'number' &&
-      (state.width < MIN_WIDTH || state.height < MIN_HEIGHT)
-    ) {
-      state = {};
-      try {
-        fs.unlinkSync(stateStoreFile);
-      } catch {
-        // ignore remove errors
+
+  // Only restore previous window bounds when not in card mode
+  if (!isCardMode) {
+    try {
+      state = JSON.parse(fs.readFileSync(stateStoreFile, 'utf8'));
+      if (
+        typeof state.width === 'number' &&
+        typeof state.height === 'number' &&
+        (state.width < MIN_WIDTH || state.height < MIN_HEIGHT)
+      ) {
+        state = {};
+        try {
+          fs.unlinkSync(stateStoreFile);
+        } catch {
+          // ignore remove errors
+        }
       }
+    } catch {
+      state = {};
     }
-  } catch {
-    state = {};
   }
 
+  const defaultWidth = isCardMode ? 384 : 1024;
+  const defaultHeight = isCardMode ? 480 : 768;
+
   mainWindow = new BrowserWindow({
-    width: state.width ?? 1024,
-    height: state.height ?? 768,
+    width: state.width ?? defaultWidth,
+    height: state.height ?? defaultHeight,
     x: state.x,
     y: state.y,
     title: 'Focana',

--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { FocusSession } from "@/api/entities";
 
-const isCardMode = import.meta.env.VITE_CARD_MODE === 'true';
+// Default to card mode unless explicitly disabled
+const isCardMode = import.meta.env.VITE_CARD_MODE !== 'false';
 
 import DistractionJar from "../components/DistractionJar";
 import StatusBar from "../components/StatusBar";
@@ -382,14 +383,14 @@ export default function AnchorApp() {
 
   return (
     <TooltipProvider>
-      <div className="min-h-screen bg-[#FFF9E6] p-4 font-sans overflow-hidden">
-        <div 
+      <div className={isCardMode ? 'w-full h-full font-sans overflow-hidden' : 'min-h-screen bg-[#FFF9E6] p-4 font-sans overflow-hidden'}>
+        <div
           ref={dragRef}
           className="w-full max-w-sm bg-[#FFFEF8]/80 backdrop-blur-sm rounded-2xl shadow-2xl shadow-amber-900/10 border border-[#8B6F47]/20 p-4 space-y-4"
           style={{
             position: 'absolute',
-            top: `${position.y}px`,
-            left: `${position.x}px`,
+            top: isCardMode ? 0 : `${position.y}px`,
+            left: isCardMode ? 0 : `${position.x}px`,
             touchAction: 'none'
           }}
         >


### PR DESCRIPTION
## Summary
- Default Electron to card mode and ignore saved bounds when enabled
- Start window at 384×480 and resize according to Anchor card
- Remove outer beige layout so Anchor card fills the window

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars, no-undef, etc.)*
- `npm run build`
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68c7272aea98832c8293fd18aca45a1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Card mode is now enabled by default (can be explicitly disabled).
  - In card mode, the app uses a compact 384x480 window with a full-bleed layout anchored to the top-left; previous window size/position isn’t restored.
  - In standard mode, the app retains the full-page layout, uses a larger 1024x768 default window, and restores the last saved size and position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->