### PR TITLE
Default Electron window to full screen

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,10 +1,11 @@
-import { app, BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain } from 'electron';
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions, ipcMain, screen } from 'electron';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
 const isDev = !app.isPackaged;
+// Enable card mode only when explicitly requested
 const isCardMode = process.env.CARD_MODE === 'true';
 
 ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
@@ -19,27 +20,36 @@ function createWindow() {
   const MIN_WIDTH = 400;
   const MIN_HEIGHT = 300;
   let state: Partial<Electron.Rectangle> = {};
-  try {
-    state = JSON.parse(fs.readFileSync(stateStoreFile, 'utf8'));
-    if (
-      typeof state.width === 'number' &&
-      typeof state.height === 'number' &&
-      (state.width < MIN_WIDTH || state.height < MIN_HEIGHT)
-    ) {
-      state = {};
-      try {
-        fs.unlinkSync(stateStoreFile);
-      } catch {
-        // ignore remove errors
+
+  // Only restore previous window bounds when not in card mode
+  if (!isCardMode) {
+    try {
+      state = JSON.parse(fs.readFileSync(stateStoreFile, 'utf8'));
+      if (
+        typeof state.width === 'number' &&
+        typeof state.height === 'number' &&
+        (state.width < MIN_WIDTH || state.height < MIN_HEIGHT)
+      ) {
+        state = {};
+        try {
+          fs.unlinkSync(stateStoreFile);
+        } catch {
+          // ignore remove errors
+        }
       }
+    } catch {
+      state = {};
     }
-  } catch {
-    state = {};
   }
 
+  const { width: screenWidth, height: screenHeight } = screen.getPrimaryDisplay().workAreaSize;
+  const defaultWidth = isCardMode ? 384 : screenWidth;
+  const defaultHeight = isCardMode ? 480 : screenHeight;
+
   mainWindow = new BrowserWindow({
-    width: state.width ?? 1024,
-    height: state.height ?? 768,
+    width: state.width ?? defaultWidth,
+    height: state.height ?? defaultHeight,
+    resizable: !isCardMode,
     x: state.x,
     y: state.y,
     title: 'Focana',
@@ -47,6 +57,10 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.cjs'),
     },
   });
+
+  if (!isCardMode && !state.width && !state.height) {
+    mainWindow.maximize();
+  }
 
   mainWindow.on('close', () => {
     if (!mainWindow) return;

--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/tooltip";
 import { FocusSession } from "@/api/entities";
 
+// Enable card mode only when explicitly requested
 const isCardMode = import.meta.env.VITE_CARD_MODE === 'true';
 
 import DistractionJar from "../components/DistractionJar";
@@ -382,14 +383,14 @@ export default function AnchorApp() {
 
   return (
     <TooltipProvider>
-      <div className="min-h-screen bg-[#FFF9E6] p-4 font-sans overflow-hidden">
-        <div 
+      <div className={isCardMode ? 'w-full h-full font-sans overflow-hidden' : 'min-h-screen bg-[#FFF9E6] p-4 font-sans overflow-hidden'}>
+        <div
           ref={dragRef}
           className="w-full max-w-sm bg-[#FFFEF8]/80 backdrop-blur-sm rounded-2xl shadow-2xl shadow-amber-900/10 border border-[#8B6F47]/20 p-4 space-y-4"
           style={{
             position: 'absolute',
-            top: `${position.y}px`,
-            left: `${position.x}px`,
+            top: isCardMode ? 0 : `${position.y}px`,
+            left: isCardMode ? 0 : `${position.x}px`,
             touchAction: 'none'
           }}
         >


### PR DESCRIPTION
## Summary
- Default Electron window to primary display dimensions and maximize on first run
- Enable card mode only when explicitly requested via `CARD_MODE`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 418 problems, mostly no-unused-vars and no-undef)*
- `npx eslint electron/main.ts src/pages/Anchor.jsx` *(warns: File ignored because no matching configuration was supplied)*
- `npm run build`
- `npm run build-electron`


------
https://chatgpt.com/codex/tasks/task_e_68c7272aea98832c8293fd18aca45a1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window size now adapts to your primary display’s available work area in non-card mode, replacing the previous fixed default.
  * On first launch (or when no window size is saved), the app opens maximized in non-card mode for better visibility.
  * Non-card mode windows are now resizable; card mode remains fixed-size (384×480) and non-resizable for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->