### PR TITLE
Gate card mode resizing and ignore tiny window state

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,19 +5,36 @@ import { autoUpdater } from 'electron-updater';
 
 let mainWindow: BrowserWindow | null = null;
 const isDev = !app.isPackaged;
+const isCardMode = process.env.CARD_MODE === 'true';
 
-ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
-  if (mainWindow) {
-    const current = mainWindow.getBounds();
-    mainWindow.setBounds({ ...current, ...bounds });
-  }
-});
+if (isCardMode) {
+  ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
+    if (mainWindow) {
+      const current = mainWindow.getBounds();
+      mainWindow.setBounds({ ...current, ...bounds });
+    }
+  });
+}
 
 function createWindow() {
   const stateStoreFile = path.join(app.getPath('userData'), 'window-state.json');
+  const MIN_WIDTH = 400;
+  const MIN_HEIGHT = 300;
   let state: Partial<Electron.Rectangle> = {};
   try {
     state = JSON.parse(fs.readFileSync(stateStoreFile, 'utf8'));
+    if (
+      typeof state.width === 'number' &&
+      typeof state.height === 'number' &&
+      (state.width < MIN_WIDTH || state.height < MIN_HEIGHT)
+    ) {
+      state = {};
+      try {
+        fs.unlinkSync(stateStoreFile);
+      } catch {
+        // ignore remove errors
+      }
+    }
   } catch {
     state = {};
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,8 +1,14 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+const isCardMode = process.env.CARD_MODE === 'true';
+
 contextBridge.exposeInMainWorld('electronAPI', {
   onWindowResize: (callback: (event: Electron.IpcRendererEvent, bounds: Electron.Rectangle) => void) =>
     ipcRenderer.on('window-resize', callback),
-  setCardBounds: (bounds: Electron.Rectangle) => ipcRenderer.send('card-bounds', bounds),
+  ...(isCardMode
+    ? {
+        setCardBounds: (bounds: Electron.Rectangle) => ipcRenderer.send('card-bounds', bounds),
+      }
+    : {}),
   versions: process.versions,
 });

--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { FocusSession } from "@/api/entities";
 
+const isCardMode = import.meta.env.VITE_CARD_MODE === 'true';
+
 import DistractionJar from "../components/DistractionJar";
 import StatusBar from "../components/StatusBar";
 import SessionNotesModal from "../components/SessionNotesModal";
@@ -77,7 +79,7 @@ export default function AnchorApp() {
 
   // Keep Electron window in sync with card size
   useEffect(() => {
-    if (!window.electronAPI?.setCardBounds || !dragRef.current) return;
+    if (!isCardMode || !window.electronAPI?.setCardBounds || !dragRef.current) return;
 
     const sendBounds = (width, height) => {
       if (width > 0 && height > 0) {


### PR DESCRIPTION
## Summary
- Only adjust Electron window bounds in card mode
- Avoid resizing desktop window from Anchor page unless in card mode
- Ignore persisted window size if below a minimum threshold

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 412 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c36f177460832c90c443ac5ebf89c6