### PR TITLE
Add window action IPC and expose renderer API

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,26 @@ ipcMain.on('card-bounds', (_event, bounds: Electron.Rectangle) => {
   }
 });
 
+ipcMain.handle('window-action', (_event, action: string) => {
+  if (!mainWindow) return;
+  switch (action) {
+    case 'close':
+      mainWindow.close();
+      break;
+    case 'minimize':
+      mainWindow.minimize();
+      break;
+    case 'restore':
+      mainWindow.restore();
+      break;
+    case 'toggle-fullscreen':
+      mainWindow.setFullScreen(!mainWindow.isFullScreen());
+      break;
+    default:
+      break;
+  }
+});
+
 function createWindow() {
   const stateStoreFile = path.join(app.getPath('userData'), 'window-state.json');
   const MIN_WIDTH = 400;
@@ -77,6 +97,15 @@ function createWindow() {
     {
       label: 'File',
       submenu: [{ role: 'quit' as const }],
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          role: 'togglefullscreen' as const,
+          accelerator: 'Ctrl+Command+F',
+        },
+      ],
     },
   ];
   const menu = Menu.buildFromTemplate(template);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,5 +10,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
         setCardBounds: (bounds: Electron.Rectangle) => ipcRenderer.send('card-bounds', bounds),
       }
     : {}),
+  windowAction: (action: string) => ipcRenderer.invoke('window-action', action),
   versions: process.versions,
 });

--- a/src/pages/Anchor.jsx
+++ b/src/pages/Anchor.jsx
@@ -429,13 +429,18 @@ export default function AnchorApp() {
                 </TooltipTrigger>
                 <TooltipContent><p>Compact Mode</p></TooltipContent>
               </Tooltip>
-               <Tooltip>
+              <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button size="icon" variant="ghost" className="h-8 w-8 text-[#8B6F47] hover:bg-[#FFF9E6]">
+                  <Button
+                    onClick={() => window.electronAPI.windowAction('close')}
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8 text-[#8B6F47] hover:bg-[#FFF9E6]"
+                  >
                     <X className="w-4 h-4" />
                   </Button>
-                  </TooltipTrigger>
-                <TooltipContent><p>Close (Placeholder)</p></TooltipContent>
+                </TooltipTrigger>
+                <TooltipContent><p>Close</p></TooltipContent>
               </Tooltip>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- handle window actions in main process via `ipcMain.handle`
- expose `windowAction` API through the preload script
- wire up UI close button to invoke `windowAction('close')`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many linter errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c76e90b300832c9e51f1b8016e33e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added window controls accessible from the app interface: close, minimize, restore, and toggle fullscreen.
  * Introduced a View menu option with a keyboard shortcut to toggle fullscreen for quicker access.
  * Made the Close button on the Anchor page functional and refined its tooltip text.
  * These additions improve desktop usability and provide consistent window management via both the UI and the application menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->