### PR TITLE
Add macOS dock icon and menu

### DIFF
--- a/electron/assets/icon.icns
+++ b/electron/assets/icon.icns
@@ -1,0 +1,1 @@
+placeholder

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -130,6 +130,12 @@ function createWindow() {
 app.whenReady().then(() => {
   createWindow();
 
+  if (app.dock) {
+    app.dock.setIcon(path.join(__dirname, 'assets/icon.icns'));
+    const menu = Menu.buildFromTemplate([{ role: 'hide' }, { role: 'quit' }]);
+    app.dock.setMenu(menu);
+  }
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });


### PR DESCRIPTION
## Summary
- add macOS dock icon placeholder
- set dock icon and hide/quit menu when app is ready

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 418 problems)

------
https://chatgpt.com/codex/tasks/task_e_68c77043d6b8832cbf57872048d4e81e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - macOS: Adds a custom app icon in the Dock and a Dock menu with Hide and Quit options. The menu is accessible via right-click on the Dock icon, enhancing native integration. Enabled only on macOS; no changes on other platforms.
- Chores
  - Added an application icon asset to support Dock customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->